### PR TITLE
Add optional workspace variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@ This module provides a layer of abstraction to accessing shared resources. It do
 
 When you add a new shared resource, you will also need to update this module with whatever outputs you want to provide access to.
 
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| workspace | TF workspace | string | `` | no |
+
 ## Outputs
 
 | Name | Description |

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@
  */
 
 locals {
-  environment = "${lower(terraform.workspace)}"
+  environment = "${var.workspace != "" ? lower(var.workspace) : lower(terraform.workspace)}"
 }
 
 data "terraform_remote_state" "global" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,4 @@
+variable "workspace" {
+  description = "TF workspace"
+  default     = ""
+}


### PR DESCRIPTION
There may be one or two cases (r53?) where we need to access both stage
and prod resources. This adds an optional workspace variable to allow
calling the module more than once for different environments. It will
default to whatever your current workspace is.