### PR TITLE
Add mitlib wildcard certificate to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ When you add a new shared resource, you will also need to update this module wit
 
 ## Outputs
 
-| Name             | Description                |
-| ---------------- | -------------------------- |
-| private_subnets  | List of private subnet IDs |
-| public_subnets   | List of public subnet IDs  |
-| vpc_id           | VPC ID                     |
-| public_zoneid    | Route53 Public Zone ID     |
-| public_zonename  | Route53 Public Zone Name   |
-| private_zoneid   | Route53 Private Zone ID    |
-| private_zonename | Route53 Private Zone Name  |
+| Name             | Description                   |
+| ---------------- | ----------------------------- |
+| private_subnets  | List of private subnet IDs    |
+| public_subnets   | List of public subnet IDs     |
+| vpc_id           | VPC ID                        |
+| public_zoneid    | Route53 Public Zone ID        |
+| public_zonename  | Route53 Public Zone Name      |
+| private_zoneid   | Route53 Private Zone ID       |
+| private_zonename | Route53 Private Zone Name     |
+| mitlib_cert      | \*.mitlib.net certificate arn |

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,3 +34,8 @@ output "private_zonename" {
   description = "Route53 Private Zone name"
   value       = "${data.terraform_remote_state.global.private_zonename}"
 }
+
+output "mitlib_cert" {
+  description = "*.mitlib.net wildcard certificate"
+  value       = "${data.terraform_remote_state.global.mitlib_cert}"
+}


### PR DESCRIPTION
Allows for the output of the arn of the *.mitlib.net certificate to be used when this module is called.