### PR TITLE
Add the SSM profile name to the shared outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ When you add a new shared resource, you will also need to update this module wit
 | public\_zoneid | Route53 Public Zone ID |
 | public\_zonename | Route53 Public Zone name |
 | vpc\_id | VPC ID |
+| ssm_profile_name | SSM Profile Name | Name of the SSM profile for the GLOBAL environment

--- a/outputs.tf
+++ b/outputs.tf
@@ -161,7 +161,13 @@ output "mit_saml_arn" {
   description = "MIT Identity provider arn (SAML Federated login)"
   value       = data.terraform_remote_state.global.outputs.mit_saml_arn
 }
+# IAM ROLES/PROFILES
 
+# SSM Profile name
+output "ssm_profile_name" {
+  description = "Name of the SSM profile for the GLOBAL environment"
+  value       = data.terraform_remote_state.global.outputs.ssm_profile_name
+}
 ##### Elastic Beanstalk Application Name Outputs #####
 
 output "docsvcs_app_name" {
@@ -210,12 +216,4 @@ output "deploy_rw_arn" {
 output "bastion_ingress_sgid" {
   description = "Security Group ID for access from Bastion host"
   value       = data.terraform_remote_state.bastion.outputs.ingress_from_bastion_sg_id
-}
-
-# IAM ROLES/PROFILES
-
-# SSM Profile name
-output "ssm_profile_name" {
-  description = "Name of the SSM profile for the GLOBAL environment"
-  value       = data.terraform_remote_state.core.outputs.ssm_profile_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -212,3 +212,10 @@ output "bastion_ingress_sgid" {
   value       = data.terraform_remote_state.bastion.outputs.ingress_from_bastion_sg_id
 }
 
+# IAM ROLES/PROFILES
+
+# SSM Profile name
+output "ssm_profile_name" {
+  description = "Name of the SSM profile for the GLOBAL environment"
+  value       = data.terraform_remote_state.core.outputs.ssm_profile_name
+}


### PR DESCRIPTION
#### Developer Checklist

- [X] The README contains the correct list of dependencies, inputs, and outputs (e.g., `terraform-docs markdown .` has been run)
- [X] Infrastructure resources in this feature are currently NOT deployed in `stage` workspace 

#### What does this PR do?

This PR adds a single output to the shared provider, ssm_profile_name.  This profile is used to attach to EC2 instances to make SSM session manager work on them

#### Helpful background context
This change is required to access the output variable from mitlib-terraform shared outputs.

#### Requires Database Migrations?
NO

#### Includes new or updated dependencies?
NO
